### PR TITLE
Use unstable PureScript in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Set up PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
         with:
+          purescript: "unstable"
           purs-tidy: "latest"
 
       - name: Cache PureScript dependencies


### PR DESCRIPTION
**Description of the change**

Switches to use unstable PureScript in CI so that release candidates are possible to use.
